### PR TITLE
Corrected error on the download strategy

### DIFF
--- a/Formula/hello-al.rb
+++ b/Formula/hello-al.rb
@@ -1,7 +1,7 @@
 class HelloAl < Formula
   desc "Homebrew tap for bottles built for armv7 Alpine proot-distro distro on termux"
   homepage "https://github.com/The-Quantum-Engineering-Guild/homebrew-hello"
-  url "https://github.com/The-Quantum-Engineering-Guild/homebrew-hello/releases/download/1.0.1/test-cpp-musl.tar.gz" using: :git
+  url "https://github.com/The-Quantum-Engineering-Guild/homebrew-hello/releases/download/1.0.1/test-cpp-musl.tar.gz", using: :git
   sha256 "f33b5a6349b78a399cba35ddcdb95b69d7dfe084f64ded0535fce6c1a0154094"
   license ""
   head "https://github.com/The-Quantum-Engineering-Guild/homebrew-hello.git"


### PR DESCRIPTION
On the setting to download from github, there was a comma missing. Typo now corrected.