### PR TITLE
Corrected the expected name of the executable

### DIFF
--- a/Formula/hello-al.rb
+++ b/Formula/hello-al.rb
@@ -7,7 +7,7 @@ class HelloAl < Formula
   head "https://github.com/The-Quantum-Engineering-Guild/homebrew-hello.git"
 
   def install
-    bin.install "hello-al"
+    bin.install "test-cpp-musl" => "hello-al"
   end
 
   def caveats


### PR DESCRIPTION
The name of the file to be downloaded wasn't matching the expected name to the installation and test.